### PR TITLE
Eco system sticker draft

### DIFF
--- a/guru/gmt-eco-system.sh
+++ b/guru/gmt-eco-system.sh
@@ -8,7 +8,7 @@
 # 4. List all the environments it can be used in
 # 5. Indicate NSF support
 
-gmt begin gmt-eco-system
+gmt begin gmt-eco-system png
 	# Thick primary and thin secondary frame with very light fill
 	gmt basemap -R-1/1/-1/1 -Jx1i -B0 -B+gseashell  --MAP_FRAME_PEN=1p
 	gmt plot -W0.25p -L <<-EOF

--- a/guru/gmt-eco-system.sh
+++ b/guru/gmt-eco-system.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Script mock up of a GMT ecosystem square sticker, to be refined
+# Goals the sticker should achieve:
+# 1. Be a square shape
+# 2. Make it clear what GMT is
+# 3. Show where to learn more
+# 4. Indicate what OS it supports
+# 4. List all the environments it can be used in
+# 5. Indicate NSF support
+
+gmt begin gmt-eco-system
+	# Thick primary and thin secondary frame with very light fill
+	gmt basemap -R-1/1/-1/1 -Jx1i -B0 -B+gseashell  --MAP_FRAME_PEN=1p
+	gmt plot -W0.25p -L <<-EOF
+	-0.98	-0.98
+	0.98	-0.98
+	0.98	0.98
+	-0.98	0.98
+	EOF
+	# Place logo without label
+	gmt logo -DjCT+w1.9i+o0/0.05i -Sn
+	# Add label and purpose
+	echo " 0 0.15 generic-mapping-tools.org" | gmt text -F+f10p,Helvetica-Bold
+	echo " 0 -0.01 Data Processing \035 Plots \035 Animations" | gmt text -F+f8.5p,Times-Italic
+	# Separating line
+	gmt plot -W0.5p <<- EOF
+	-0.95	-0.12
+	0.95	-0.12
+	EOF
+	# Place QR code
+	echo 0 -0.4 | gmt plot -SkQR/0.55i
+	# Ecosystem identifiers
+	gmt text -F+f9p,Helvetica-Bold,darkgreen+jCM <<- EOF
+	-0.65 -0.22 CMD
+	-0.65 -0.4 JULIA
+	-0.65 -0.58 MATLAB
+	0.65 -0.22 OCTAVE
+	0.65 -0.4 PYTHON
+	0.65 -0.58 SHELL
+	EOF
+	# OS supported
+	echo "Linux \031 macOS \031 Windows" | gmt text -F+cBC+f8p,Helvetica-Bold,navy -Dj0/0.18i
+	# Funding
+	echo "SUPPORTED BY THE US NATIONAL SCIENCE FOUNDATION" | gmt text -F+cBC+f4.75p,Helvetica-Bold -Dj0/0.05i
+gmt end show

--- a/guru/gmt-eco-system.sh
+++ b/guru/gmt-eco-system.sh
@@ -5,8 +5,8 @@
 # 2. Make it clear what GMT is
 # 3. Show where to learn more
 # 4. Indicate what OS it supports
-# 4. List all the environments it can be used in
-# 5. Indicate NSF support
+# 5. List all the environments it can be used in
+# 6. Indicate NSF support
 
 gmt begin gmt-eco-system png
 	# Thick primary and thin secondary frame with very light fill

--- a/guru/insertcall.c
+++ b/guru/insertcall.c
@@ -1,0 +1,27 @@
+/* Simple program to assist in adding lines like
+ * 	n_errors += gmt_M_repeated_module_option (API, Ctrl->F.active);
+ * just after the case 'F' in a module, for all cases.
+ * Most module options are only allowed once, so we will need to
+ * edit for the few that are repetitive (-G in grdtrack, -S in subplot
+ * and others).  Keeping a record of what was done by saving this program
+ * in the sandbox.
+ * Paul Wessel, 9/1/2021.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+int main () {
+	char line[512] = {""};
+	int on = 0;
+
+	while (fgets (line, 512, stdin)) {
+		printf ("%s", line);
+		if (!strncmp (line, "static int parse", 16U)) on = 1;
+		else if (on && line[0] == '}') on = 0;
+		if (on && !strncmp (line, "			case '", 9U) && strchr ("><", line[9]) == NULL && isupper (line[9])) {
+			printf ("				n_errors += gmt_M_repeated_module_option (API, Ctrl->%c.active);\n", line[9]);
+		}
+	}
+}

--- a/gurudocs/sphellipse.tex
+++ b/gurudocs/sphellipse.tex
@@ -1,0 +1,107 @@
+%	$Id$
+% Internal documentation for Solving GPSgridder
+% Paul Wessel, November 16, 2016.
+\documentclass[12pt,letterpaper,margin=0.5in]{report}
+\usepackage{times}
+\usepackage{graphicx}
+\usepackage{breqn}
+\usepackage[margin=0.5in]{geometry}
+\usepackage{lscape}
+\textheight = 9 in
+\topmargin = -1 in
+\begin{document}
+
+\section{GPSGRIDDER MATRIX SOLUTION}
+
+We refer to equation (9) in {\it Sandwell and Wessel} [2016].  This equation constitutes a linear system {\bf Ax} = {\bf b}
+of dimensions $2n$ by $2n$
+given we have $n$ pairs of ($u_i, v_i$) observations. We can write this as
+
+
+% MathType!MTEF!2!1!+-
+% faaagCart1ev2aaaKnaaaaWenf2ys9wBH5garuavP1wzZbqedmvETj
+% 2BSbqefm0B1jxALjharqqtubsr4rNCHbGeaGqiVu0Je9sqqrpepe0t
+% bbL8FesqqrFfpeea0xe9Lq-Jc9vqaqpepm0xbba9pwe9Q8fs0-yqaq
+% pepae9pg0FirpepeKkFr0xfr-xfr-xb9Gqpi0dc9adbaqaaeGaciGa
+% aiaabeqaamaabaabaaGcbaWaamWaaeaafaWabeGbgaeaabqaaiaadE
+% gadaWgaaWcbaGaaGymaiaacYcacaaIXaaabeaakiaadEhadaqhaaWc
+% baGaaGymaaqaaaaaaOqaaiabl+UimbqaaiaadEgadaWgaaWcbaGaaG
+% ymaiaacYcacaWGUbaabeaakiaadEhadaqhaaWcbaGaaGymaaqaaaaa
+% aOqaaiaadEgadaWgaaWcbaGaaGymaiaacYcacaWGUbGaey4kaSIaaG
+% ymaaqabaGccaWG3bWaa0baaSqaaiaaigdaaeaaaaaakeaacqWIVlct
+% aeaacaWGNbWaaSbaaSqaaiaaigdacaGGSaGaamOBaiabgUcaRiaad2
+% gaaeqaaOGaam4DamaaDaaaleaacaaIXaaabaaaaaGcbaGaeSO7I0ea
+% baGaeSy8I8eabaGaeSO7I0eabaGaeSO7I0eabaGaeSy8I8eabaGaeS
+% O7I0eabaGaam4zamaaBaaaleaacaWGUbGaaiilaiaaigdaaeqaaOGa
+% am4DamaaDaaaleaacaWGUbaabaaaaaGcbaGaeS47IWeabaGaam4zam
+% aaBaaaleaacaWGUbGaaiilaiaad6gaaeqaaOGaam4DamaaDaaaleaa
+% caWGUbaabaaaaaGcbaGaam4zamaaBaaaleaacaWGUbGaaiilaiaad6
+% gacqGHRaWkcaaIXaaabeaakiaadEhadaqhaaWcbaGaamOBaaqaaaaa
+% aOqaaiabl+UimbqaaiaadEgadaWgaaWcbaGaamOBaiaacYcacaWGUb
+% Gaey4kaSIaamyBaaqabaGccaWG3bWaa0baaSqaaiaad6gaaeaaaaaa
+% keaacaWGKbWaaSbaaSqaaiaad6gacqGHRaWkcaaIXaGaaiilaiaaig
+% daaeqaaOGaam4DamaaDaaaleaacaWGUbGaey4kaSIaaGymaaqaaaaa
+% aOqaaiabl+UimbqaaiaadsgadaWgaaWcbaGaamOBaiabgUcaRiaaig
+% dacaGGSaGaamOBaaqabaGccaWG3bWaa0baaSqaaiaad6gacqGHRaWk
+% caaIXaaabaaaaaGcbaGaaGimaaqaaiabl+UimbqaaiaadsgadaWgaa
+% WcbaGaamOBaiabgUcaRiaaigdacaGGSaGaamOBaiabgUcaRiaad2ga
+% aeqaaOGaam4DamaaDaaaleaacaWGUbGaey4kaSIaaGymaaqaaaaaaO
+% qaaiabl6UinbqaaiablgVipbqaaiabl6Uinbqaaiabl6Uinbqaaiab
+% lgVipbqaaiabl6UinbqaaiaadsgadaWgaaWcbaGaamOBaiabgUcaRi
+% aad2gacaGGSaGaaGymaaqabaGccaWG3bWaa0baaSqaaiaad6gacqGH
+% RaWkcaWGTbaabaaaaaGcbaGaeS47IWeabaGaamizamaaBaaaleaaca
+% WGUbGaey4kaSIaamyBaiaacYcacaWGUbaabeaakiaadEhadaqhaaWc
+% baGaamOBaiabgUcaRiaad2gaaeaaaaaakeaacaWGKbWaaSbaaSqaai
+% aad6gacqGHRaWkcaWGTbGaaiilaiaad6gacqGHRaWkcaaIXaaabeaa
+% kiaadEhadaqhaaWcbaGaamOBaiabgUcaRiaad2gaaeaaaaaakeaacq
+% WIVlctaeaacaaIWaaaaaGaay5waiaaw2faaiabgwSixpaadmaabaqb
+% amqabyqaabaabaGaeqySde2aaSbaaSqaaiaaigdaaeqaaaGcbaGaeS
+% O7I0eabaGaeqySde2aaSbaaSqaaiaad6gaaeqaaaGcbaGaeqySde2a
+% aSbaaSqaaiaad6gacqGHRaWkcaaIXaaabeaaaOqaaiabl6Uinbqaai
+% abeg7aHnaaBaaaleaacaWGUbGaey4kaSIaamyBaaqabaaaaaGccaGL
+% BbGaayzxaaGaeyypa0ZaamWaaeaafaWabeGbbaeaaeaacaWG6bWaaS
+% baaSqaaiaaigdaaeqaaOGaam4DamaaDaaaleaacaaIXaaabaaaaaGc
+% baGaeSO7I0eabaGaamOEamaaBaaaleaacaWGUbaabeaakiaadEhada
+% qhaaWcbaGaamOBaaqaaaaaaOqaaiaadohadaWgaaWcbaGaaGymaaqa
+% baGccaWG3bWaa0baaSqaaiaad6gacqGHRaWkcaaIXaaabaaaaaGcba
+% GaeSO7I0eabaGaam4CamaaBaaaleaacaWGTbaabeaakiaadEhadaqh
+% aaWcbaGaamOBaiabgUcaRiaad2gaaeaaaaaaaaGccaGLBbGaayzxaa
+% aaaa!F91F!
+\[
+\left[ {\begin{array}{*{20}{c}}
+{{q_{11}}w_1^{u}}& \cdots &{{q_{1n}}w_1^{u}}&\vline& {{w_{11}}w_1^{u}}& \cdots &{{w_{1n}}w_1^{u}}\\
+ \vdots & \ddots & \vdots &\vline&  \vdots & \ddots & \vdots \\
+{{q_{n1}}w_n^{u}}& \cdots &{{q_{nn}}w_n^{u}}&\vline& {{w_{n1}}w_n^{u}}& \cdots &{{w_{nn}}w_n^{u}}\\
+\hline
+{{w_{11}}w_{1}^{v}}& \cdots &{{w_{1n}}w_{1}^{v}}&\vline& {{p_{11}}w_{1}^{v}}& \cdots &{{p_{1n}}w_{1}^{v}}\\
+ \vdots & \ddots & \vdots &\vline&  \vdots & \ddots & \vdots \\
+{{w_{n1}}w_{n}^{v}}& \cdots &{{w_{nn}}w_{n}^{v}}&\vline& {{p_{n1}}w_{n}^{v}}& \cdots &{{p_{nn}}w_{n}^{v}}
+\end{array}} \right] \cdot \left[ {\begin{array}{*{20}{c}}
+{{f _x^1}}\\
+ \vdots \\
+{{f _x^n}}\\
+\hline
+{{f _y^1}}\\
+ \vdots \\
+{{f _y^n}}
+\end{array}} \right] = \left[ {\begin{array}{*{20}{c}}
+{{u_1}w_1^{u}}\\
+ \vdots \\
+{{u_n}w_n^{u}}\\
+\hline
+{{v_1}w_1^{v}}\\
+ \vdots \\
+{{v_m}w_n^{v}}
+\end{array}} \right]
+\]
+
+Here, $q_{ij}$, $w_{ij}$, and $p_{ij}$ are the Green’s functions given by equation (8) and evaluated for the
+radial distance between points $i$ and $j$.  Note we have scaled each equation by the weight $w_i$
+(= $1/\sigma_i$) for the $i$’th data measurement; for unweighted data, these are all unity.
+Having solved for the forces ${\mathbf f}_x$ and ${\mathbf f}_y$ we evaluate the solution using (10).
+
+\section{REFERENCES}
+
+Sandwell, D. T., and P. Wessel (2016), Interpolation of 2-D vector data using constraints from elasticity,
+{\it Geophys. Res. Lett., 43}, 10,703--10,709, doi:10.1002/2016GL070340.
+\end{document}


### PR DESCRIPTION
Given the discussion in PyGMT about a PyGMT logo, I thought I would follow up with some suggestion for an overarching GMT ecosystem sticker.  THis would not replace whatever Julia or Python or Matlab stickers people would like to make, but it would be a good way to advertise the broad applicability of GMT I hope.  This is just a draft - comments from @GenericMappingTools/core encouraged.  I tried to satisfy these boundary conditions:

1. Be a square shape
2. Make it clear what GMT can do
3. Show where to learn more
4. Indicate what OS it supports
5. List all the environments it can be used in
6. Indicate NSF support

So there is a bit of text, but it at least hits on all 6.  Looks like this for now:

![gmt-eco-system](https://user-images.githubusercontent.com/26473567/109236642-21af9980-7774-11eb-9d01-2160f78b0aba.png)

I am open to related subtle changes like removing the gridlines from the map, for instance, and tinker with colors in the main logo.  The rest can be changed willy-nilly.
